### PR TITLE
Fix miscellaneous typos

### DIFF
--- a/src/TurkeyWeather.ts
+++ b/src/TurkeyWeather.ts
@@ -238,10 +238,10 @@ export class TurkeyWeather {
      *
      * @example
      * // Fetch the daily weather forecast for Trabzon
-     * const forecast = await DailyForcast("Trabzon");
+     * const forecast = await DailyForecast("Trabzon");
      * console.log(forecast);
      */
-    async DailyForcast(centerInput: string | number, districtName: string = ''): Promise<CastedDailyForecast[]> {
+    async DailyForecast(centerInput: string | number, districtName: string = ''): Promise<CastedDailyForecast[]> {
         // Get center ID if the parameters are a province name or a district name.
         if (typeof centerInput !== 'number') {
             centerInput = await this.getCenterIDfromName(centerInput, districtName);

--- a/src/TurkeyWeather.ts
+++ b/src/TurkeyWeather.ts
@@ -108,7 +108,7 @@ export class TurkeyWeather {
             centerInput = convertTurkishCharacters(centerInput);
             urlPath = 'merkezler?il=' + centerInput;
 
-            // If there is a distric name given, add it to the URL path.
+            // If there is a district name given, add it to the URL path.
             if (districtName !== '') {
                 districtName = convertTurkishCharacters(districtName);
                 urlPath = urlPath + '&ilce=' + districtName;

--- a/tests/errorchecking.test.ts
+++ b/tests/errorchecking.test.ts
@@ -8,7 +8,7 @@ test('Test fot non english inputs in parameters', async () => {
         api.getDistricts("niĞdE");
         api.getCenterInfo("niĞdE");
         api.LatestEvents("niĞdE");
-        api.DailyForcast("niĞdE");
+        api.DailyForecast("niĞdE");
         api.HourlyForecast("niĞdE");
     }).not.toThrow()
 })
@@ -18,5 +18,5 @@ test('Tests for correct error responses', async () => {
     await expect(api.getCenterInfo('NonExistingCityName')).rejects.toThrow(Error)
     await expect(api.LatestEvents('NonExistingCityName')).rejects.toThrow(Error)
     await expect(api.HourlyForecast('NonExistingCityName')).rejects.toThrow(Error)
-    await expect(api.DailyForcast('NonExistingCityName')).rejects.toThrow(Error)
+    await expect(api.DailyForecast('NonExistingCityName')).rejects.toThrow(Error)
 })

--- a/tests/weather.test.ts
+++ b/tests/weather.test.ts
@@ -10,17 +10,17 @@ test('getProvinceNames()', async () => {
 })
 
 test('getDistricts()',async () => {
-    const districs = await api.getDistricts("Niğde");
+    const districts = await api.getDistricts("Niğde");
 })
 
 test('getCenterInfo()',async () => {
     const province = await api.getCenterInfo("Trabzon");
     expect(province.provinceID).toBe(60);
 
-    const distric = await api.getCenterInfo("Trabzon", "Ortahisar");
-    expect(distric.provinceID).toBe(60);
-    expect(distric.province).toBe("Trabzon");
-    expect(distric.name).toBe("Ortahisar");
+    const district = await api.getCenterInfo("Trabzon", "Ortahisar");
+    expect(district.provinceID).toBe(60);
+    expect(district.province).toBe("Trabzon");
+    expect(district.name).toBe("Ortahisar");
 })
 
 test('LatestEvents()',async () => {

--- a/tests/weather.test.ts
+++ b/tests/weather.test.ts
@@ -29,7 +29,7 @@ test('LatestEvents()',async () => {
 })
 
 test('DailyForecast()',async () => {
-    const forecast = await api.DailyForcast("Trabzon", "Ortahisar");
+    const forecast = await api.DailyForecast("Trabzon", "Ortahisar");
     expect(forecast).toHaveLength(5);
     expect(forecast[0].temp).toBeDefined();
 })


### PR DESCRIPTION
I noticed a few typos in the code, namely the `DailyForcast` function that is supposed to be `DailyForecast`. I have also updated the tests and verified they all still pass after this change.